### PR TITLE
build: Setup release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency: release
+    permissions:
+      id-token: write
+      contents: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/openyieldtables
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Create semantic release
+      - name: Python Semantic Release
+        id: release
+        uses: python-semantic-release/python-semantic-release@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Publish to PyPI
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+        # See https://github.com/actions/runner/issues/1173
+        if: steps.release.outputs.released == 'true'
+
+      # Publish to GitHub Releases
+      - name: Publish package distributions to GitHub Releases
+        uses: python-semantic-release/upload-to-gh-release@main
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,3 +147,23 @@ To build the documentation, use:
 ```bash
 poetry run mkdocs build
 ```
+
+### Releases (Commit message format)
+
+The repository uses [python-semantic-release](https://python-semantic-release.readthedocs.io/en/latest/)
+to make automated releases in workflows. `python-semantic-release` uses the
+commit messages to determine the consumer impact of changes in the codebase.
+Following formalized conventions for commit messages, semantic-release
+automatically determines the next semantic version number, generates a
+changelog and publishes the release.
+
+The table below shows which commit message gets you which release type when
+`python-semantic-release` runs:
+
+| Commit message                                                                                                                                                                                                                    | Release type                                                                                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `fix: Handle case when yield_class is a float`                                                                                                                                                                                    | ~~Patch~~ Fix Release                                                                                           |
+| `feat: Add a 'title' parameter to the get_yield_table_data function`                                                                                                                                                              | ~~Minor~~ Feature Release                                                                                       |
+| `fix: Rename 'diameter' to 'dbh' in the YieldTable model`<br><br>`BREAKING CHANGE: The 'diameter' field has been replaced with 'dbh'.`<br>`It's not possible anymore to reference the 'diameter' field in a YieldTable instance.` | ~~Major~~ Breaking Release <br /> (Note that the `BREAKING CHANGE: ` token must be in the footer of the commit) |
+
+For more information on the commit message format, see this guideline: https://gist.github.com/brianclements/841ea7bffdb01346392c#file-commit-formatting-md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ force_sort_within_sections = true
 python_version = "3.9"
 warn_return_any = true
 
+[tool.semantic_release]
+version_toml = ["pyproject.toml:tool.poetry.version"]
+branch = "main"
+build_command = "pip install poetry==1.8.2 && poetry build"
+
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"
 pytest-cov = "^5.0.0"


### PR DESCRIPTION
Story: https://trello.com/c/EcTa6xkU/446-enable-fmm-to-create-m2m-feasibility-study-13-21


Resources:
https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#github-action-no-longer-publishes-artefacts-to-pypi-or-github-releases

https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#the-whole-ci-cd-workflow

https://mestrak.com/blog/semantic-release-with-python-poetry-github-actions-20nn