### PR TITLE
docs: Add project meta data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,12 @@
 name = "openyieldtables"
 version = "0.0.0"
 description = ""
-authors = ["Tree.ly", "FMM"]
+authors = ["Tree.ly <hello@tree.ly>", "FMM <fmm@fmm.at>"]
+maintainers = ["FMM <fmm@fmm.at>", "Tree.ly <hello@tree.ly>"]
 readme = "README.md"
 license = "MIT"
+repository = "https://github.com/treely/openyieldtables"
+documentation = "https://openyieldtables.readthedocs.io"
 packages = [
   { include = "openyieldtables", from = "src" },
   { include = "src/openyieldtables/py.typed" },


### PR DESCRIPTION
Python packages can only have one `Author` and one `Maintainer` per definition: https://packaging.python.org/en/latest/specifications/core-metadata/#author

However, in the `pyproject.toml` file these fields allow lists as input. I think that only the first list entry gets picked up during packaging. Hence, I propose putting `FMM` first as maintainer and `Tree.ly` first as author. 

In the documentation it is clear, that both `Tree.ly` and `FMM` are maintaining the package. 


