### PR TITLE
test: Remove length assertion in test-api-yieldtablesmeta

### DIFF
--- a/tests/test_api_yieldtablesmeta.py
+++ b/tests/test_api_yieldtablesmeta.py
@@ -9,7 +9,6 @@ client = TestClient(app, headers={"accept": "application/json"})
 def test_read_yield_tables_meta():
     response = client.get("/v1/yield-tables-meta")
     assert response.status_code == 200
-    assert len(response.json()) == 49
     assert response.json()[0] == {
         "id": 1,
         "title": "Fichte Hochgebirge",


### PR DESCRIPTION
### Checklist

- [ ] The docs are up-to-date
- [ ] The commit message follows the [guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format)
- [ ] The roadmap is up to date
